### PR TITLE
Removed the hidden "Related Topics" block from the sidebar.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -101,6 +101,15 @@ html_static_path = ['_static']
 # This is required for the alabaster theme
 # refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
 
+html_sidebars = {
+    '**': [
+        'localtoc.html',
+        'sourcelink.html',
+        'searchbox.html'
+    ]
+}
+
+
 html_theme_options = {
     'sidebar_collapse': True
     }


### PR DESCRIPTION
Explicitly defined a sidebar that didn't have relations.html in it.

Changing the boolean value of show_related in html_theme_options,
too, changes the visibility of this block but it does so by only
changing its CSS 'display' property and not actually adding or
removing it from the final html.